### PR TITLE
Update to the new SGX check response

### DIFF
--- a/skale_checks/checks/watchdog.py
+++ b/skale_checks/checks/watchdog.py
@@ -89,8 +89,14 @@ class WatchdogChecks(BaseChecks):
         if not sgx_response.is_status_ok():
             return None, None
         sgx_data = sgx_response.payload
-        is_sgx_working = (sgx_data['status'] == 0 and
-                          sgx_data['status_name'] == SGX_CONNECTED_STATUS)
+        status_zmg = sgx_data.get('status_zmq', None)
+        status_https = sgx_data.get('status_https', None)
+        if status_zmg is None and status_https is None:
+            status_zmg = sgx_data.get('status', None)
+            status_https = sgx_data.get('status_name', None)
+            is_sgx_working = status_zmg == 0 and status_https == SGX_CONNECTED_STATUS
+        else:
+            is_sgx_working = status_zmg is True and status_https is True
         sgx_version_check = sgx_data['sgx_wallet_version'] in self.requirements['versions']['sgx']
         return is_sgx_working, sgx_version_check
 


### PR DESCRIPTION
Changes are related to a new watchdog response on SGX check request

**Old response:**
`{"data": {"status": 0, "status_name": "CONNECTED", "sgx_wallet_version": "1.9.0"}, "error": null}`

**New response:**
`{"data": {"status_zmq": true, "status_https": true, "sgx_wallet_version": "1.9.0"}, "error": null}`

Temporary a support for both type of responds are implemented (can be removed after updating all SKALE nodes to 3.1 release)