### PR TITLE
Fix upload to PyPi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel twine
+        pip install -e .
         pip install -e .[dev]
     - name: Build library
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged
+    permissions:
+      contents: write
     strategy:
       matrix:
         python-version: [3.11]
@@ -27,10 +29,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -e .
+        python -m pip install --upgrade pip setuptools wheel twine
         pip install -e .[dev]
-        pip install wheel
     - name: Build library
       run: |
         export BRANCH=${GITHUB_REF##*/}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,11 @@ jobs:
       PIP_USERNAME: ${{ secrets.PIP_USERNAME }}
       PIP_PASSWORD: ${{ secrets.PIP_PASSWORD }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install python dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,10 +40,7 @@ jobs:
         echo "Version $VERSION"
         bash ./scripts/build.sh
     - name: Publish to pip
-      run: |
-        bash ./scripts/publish.sh
-    - name: Checkout code
-      uses: actions/checkout@master
+      run: bash ./scripts/publish.sh
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,8 @@
 : "${PIP_USERNAME?Need to set PIP_USERNAME}"
 : "${PIP_PASSWORD?Need to set PIP_PASSWORD}"
 
-if [ $TEST = 1 ]; then
+if [ "$TEST" = "1" ]; then
+    echo "Uploading to testpypi"
     twine upload --repository testpypi dist/*
 else
     echo "Uploading to pypi"


### PR DESCRIPTION
This pull request updates the publishing workflow and related scripts to improve compatibility, security, and reliability in the CI/CD pipeline. The main changes include upgrading GitHub Actions to their latest versions, modifying permissions, and refining the publishing script for environment variable handling.

**GitHub Actions Workflow Modernization:**

* Upgraded `actions/checkout` and `actions/setup-python` to version 5 in `.github/workflows/publish.yml` for improved reliability and security, and added `fetch-depth: 0` to ensure full git history is available.
* Added explicit `contents: write` permissions to the build job in `.github/workflows/publish.yml` to support release creation and artifact uploads.

**Python Dependency and Build Improvements:**

* Consolidated Python dependency installation by upgrading `pip`, `setuptools`, `wheel`, and `twine` in a single step, and removed redundant installation of `wheel`.

**Publishing Script Refinement:**

* Improved the environment variable comparison in `scripts/publish.sh` by quoting `$TEST` to prevent errors when the variable is unset, and added an echo statement to clarify when publishing to TestPyPI.

**Workflow Cleanup:**

* Removed redundant code checkout step after publishing in `.github/workflows/publish.yml` to streamline the workflow.