### PR TITLE
Use Python 3.13 only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.13]
     env:
       PIP_USERNAME: ${{ secrets.PIP_USERNAME }}
       PIP_PASSWORD: ${{ secrets.PIP_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12, 3.13]
+        python-version: [3.13]
 
     steps:
     - uses: actions/checkout@v5

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "elasticsearch>=7.17.6,<8",  # Latest 7.x, compatible with Python 3.13 and ES 7.x
         "PyYAML==6.0.3"
     ],
-    python_requires='>=3.12,<4',
+    python_requires='>=3.13,<4',
     extras_require=extras_require,
     keywords=['skale', 'checks'],
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python ::  3.13',
     ]
 )


### PR DESCRIPTION
This pull request updates the supported Python versions for the project, focusing support exclusively on Python 3.13. The changes ensure that all testing, publishing, and metadata reflect this updated version requirement.

**Python version support updates:**

* Updated the test workflow in `.github/workflows/test.yml` to only run tests on Python 3.13, removing support for Python 3.12.
* Updated the publish workflow in `.github/workflows/publish.yml` to only publish for Python 3.13, removing support for Python 3.11.

**Project metadata update:**

* Modified `setup.py` to only declare support for Python 3.13 in the `classifiers`, removing references to Python 3.11 and 3.12.