### PR TITLE
Update skale.py to 7.10dev3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author_email='support@skalelabs.com',
     url='https://github.com/skalenetwork/skale-checks',
     install_requires=[
-        "skale.py>=7.6dev0,<8",
+        "skale.py>=7.10.dev3,<8",
         "elasticsearch>=7.17.6,<8",  # Latest 7.x, compatible with Python 3.13 and ES 7.x
         "PyYAML==6.0.3"
     ],

--- a/skale_checks/checks/node.py
+++ b/skale_checks/checks/node.py
@@ -85,10 +85,15 @@ class NodeChecks(WatchdogChecks):
     def internal_ports(self) -> bool:
         """ Checks that internal ports are not accessible from the host """
         node_id = self.node['id']
-        active_schains_hashes = self.skale.schains_internal.get_active_schain_hashes_for_node(node_id)
+        active_schains_hashes = self.skale.schains_internal.get_active_schain_hashes_for_node(
+            node_id)
         schains_hashes = self.skale.schains_internal.get_schain_hashes_for_node(node_id)
         for schain_hash in active_schains_hashes:
-            schain_base_port = get_schain_base_port_on_node(schains_hashes, schain_hash, self.node['port'])
+            schain_base_port = get_schain_base_port_on_node(
+                schains_hashes,
+                schain_hash,
+                self.node['port']
+            )
             for offset_endpoint in [
                 SkaledPorts.PROPOSAL.value,
                 SkaledPorts.CATCHUP.value,

--- a/skale_checks/checks/node.py
+++ b/skale_checks/checks/node.py
@@ -85,11 +85,10 @@ class NodeChecks(WatchdogChecks):
     def internal_ports(self) -> bool:
         """ Checks that internal ports are not accessible from the host """
         node_id = self.node['id']
-        active_schains_ids = self.skale.schains_internal.get_active_schain_ids_for_node(node_id)
-        schains = self.skale.schains.get_schains_for_node(node_id)
-        for schain_id in active_schains_ids:
-            schain_name = self.skale.schains.get(schain_id).name
-            schain_base_port = get_schain_base_port_on_node(schains, schain_name, self.node['port'])
+        active_schains_hashes = self.skale.schains_internal.get_active_schain_hashes_for_node(node_id)
+        schains_hashes = self.skale.schains_internal.get_schain_hashes_for_node(node_id)
+        for schain_hash in active_schains_hashes:
+            schain_base_port = get_schain_base_port_on_node(schains_hashes, schain_hash, self.node['port'])
             for offset_endpoint in [
                 SkaledPorts.PROPOSAL.value,
                 SkaledPorts.CATCHUP.value,


### PR DESCRIPTION
This pull request updates dependencies and refactors how internal ports are checked for nodes to improve compatibility and maintainability. The most important changes are grouped below:

**Dependency Updates:**

* Updated the `skale.py` dependency version in `setup.py` to require at least `7.10.dev3` instead of `7.6dev0`, ensuring compatibility with newer features and bug fixes.

**Internal Port Check Refactor:**

* Refactored the `internal_ports` method in `skale_checks/checks/node.py` to use schain hashes instead of schain IDs and names, aligning with updated data structures for schain management.